### PR TITLE
Update v1.2.0

### DIFF
--- a/YunYunLoader/ModdedLevelData.cs
+++ b/YunYunLoader/ModdedLevelData.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 using YYNoteEditor;
 
 namespace YunYunLoader

--- a/YunYunLoader/ModdedScoreData.cs
+++ b/YunYunLoader/ModdedScoreData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using YYNoteEditor;
+﻿using System.Collections.Generic;
 
 namespace YunYunLoader
 {
@@ -8,8 +6,10 @@ namespace YunYunLoader
     {
         public string? ID;
         public string? Audio;
+        public string? Icon;
         public string? Title;
         public string? Artist;
+        public string? ListArtist;
         public string? Lyricist;
         public string? Composer;
         public string? Arranger;

--- a/YunYunLoader/Patches/DataStorage_Patches.cs
+++ b/YunYunLoader/Patches/DataStorage_Patches.cs
@@ -6,9 +6,7 @@ using HarmonyLib;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using ILib.ServInject;
 using UnityEngine;
-using YunyunLoader;
 
 namespace YunYunLoader.Patches
 {
@@ -66,7 +64,7 @@ namespace YunYunLoader.Patches
 
     /* Song dumping for development
     [HarmonyPatch]
-    internal class DataStorage_Dump
+    internal class DataStorage_Dump 
     {
         private static MethodBase TargetMethod()
         {

--- a/YunYunLoader/Patches/DataStorage_Patches.cs
+++ b/YunYunLoader/Patches/DataStorage_Patches.cs
@@ -31,10 +31,10 @@ namespace YunYunLoader.Patches
         private static async UniTask<ScoreDataSet> AppendCustomData(ModdedScoreData data, int level)
         {
             await UniTask.CompletedTask;
-            if (!Plugin.LoadedAudioClips.TryGetValue(Path.GetFileNameWithoutExtension(data.Audio), out AudioClip clip))
+            if (data.ID is null || data.Levels is null || !Plugin.LoadedAudioClips.TryGetValue(data.ID, out AudioClip clip))
                 return null!;
             ModdedLevelData? levelData = data.Levels.FirstOrDefault(x => x.Data!.Level == level);
-            if (levelData == null)
+            if (levelData is null)
                 return null!;
             return new ScoreDataSet
             {

--- a/YunYunLoader/Patches/InGameResultScene_Patches.cs
+++ b/YunYunLoader/Patches/InGameResultScene_Patches.cs
@@ -7,7 +7,6 @@ using HarmonyLib;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using YunyunLoader;
 
 namespace YunYunLoader.Patches
 {

--- a/YunYunLoader/Patches/ScoreSelectScene_Patches.cs
+++ b/YunYunLoader/Patches/ScoreSelectScene_Patches.cs
@@ -21,9 +21,12 @@ namespace YunYunLoader.Patches
             // local ScoreData class is private
             Type scoreDataType = AccessTools.TypeByName("App.ScoreSelectScene+ScoreData");
 
-            foreach (var data in Plugin.ModdedSongs.Values)
+            foreach (ModdedScoreData data in Plugin.ModdedSongs.Values)
             {
                 object? newScoreData;
+                
+                if (data.ID is null)
+                    continue;
 
                 if (!dict.Contains(data.ID))
                 {
@@ -41,8 +44,7 @@ namespace YunYunLoader.Patches
                 
                 // build our fake ScoreInfo data
                 FieldInfo infosField = AccessTools.Field(scoreDataType, "Infos");
-                IDictionary? infos = infosField.GetValue(newScoreData) as IDictionary;
-                if (infos == null)
+                if (!(infosField.GetValue(newScoreData) is IDictionary infos))
                 {
                     Plugin.Log.LogError("Failed to get Infos dictionary.");
                     continue;
@@ -53,8 +55,7 @@ namespace YunYunLoader.Patches
 
                 // build our fake ScoreLevelData data
                 FieldInfo levelsField = AccessTools.Field(scoreDataType, "Levels");
-                IDictionary? levels = levelsField.GetValue(newScoreData) as IDictionary;
-                if (levels == null)
+                if (!(levelsField.GetValue(newScoreData) is IDictionary levels))
                 {
                     Plugin.Log.LogError("Failed to get Levels dictionary.");
                     continue;

--- a/YunYunLoader/Patches/ScoreSelectScene_Patches.cs
+++ b/YunYunLoader/Patches/ScoreSelectScene_Patches.cs
@@ -4,7 +4,6 @@ using HarmonyLib;
 using System;
 using System.Collections;
 using System.Reflection;
-using YunyunLoader;
 
 namespace YunYunLoader.Patches
 {

--- a/YunYunLoader/Patches/SoundMediator_Patches.cs
+++ b/YunYunLoader/Patches/SoundMediator_Patches.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
 using UnityEngine;
-using YunyunLoader;
 
 namespace YunYunLoader.Patches
 {

--- a/YunYunLoader/Patches/SoundMediator_Patches.cs
+++ b/YunYunLoader/Patches/SoundMediator_Patches.cs
@@ -30,8 +30,7 @@ namespace YunYunLoader.Patches
 
         private static void SetClip(AudioSource source, AudioClip clip, SoundMediator self)
         {
-            string? current = AccessTools.Field(typeof(SoundMediator), "m_PlayCurrent").GetValue(self) as string;
-            if (current == null)
+            if (!(AccessTools.Field(typeof(SoundMediator), "m_PlayCurrent").GetValue(self) is string current))
             {
                 // if we can't get the current song, mirror original behavior
                 source.clip = clip;
@@ -40,7 +39,7 @@ namespace YunYunLoader.Patches
 
             if (Plugin.ModdedSongs.TryGetValue(current, out ModdedScoreData result))
             {
-                if (Plugin.LoadedAudioClips.TryGetValue(Path.GetFileNameWithoutExtension(result.Audio), out AudioClip c))
+                if (result.ID != null && Plugin.LoadedAudioClips.TryGetValue(result.ID, out AudioClip c))
                 {
                     source.clip = c;
                 }

--- a/YunYunLoader/Patches/UIScoreDetail_Patches.cs
+++ b/YunYunLoader/Patches/UIScoreDetail_Patches.cs
@@ -1,9 +1,8 @@
-﻿using App;
+﻿using System.IO;
+using App;
 using App.Binding;
-using App.Data;
 using HarmonyLib;
-using System.Linq;
-using YunyunLoader;
+using UnityEngine;
 
 namespace YunYunLoader.Patches
 {
@@ -12,13 +11,20 @@ namespace YunYunLoader.Patches
     {
         private static bool Prefix(string musicID, UIScoreDetail __instance)
         {
-            if (Plugin.TryGetSongByTitle(musicID, out ModdedScoreData data))
+            if (Plugin.ModdedSongs.TryGetValue(musicID, out ModdedScoreData? data))
             {
+                if (data == null)
+                    return true;
+
+                __instance.MusicId = musicID;
+                Sprite? icon = null;
+                __instance.HasMusicLogo = !string.IsNullOrWhiteSpace(data.Icon) && Plugin.LoadedSprites.TryGetValue(Path.GetFileNameWithoutExtension(data.Icon), out icon);
+                __instance.MusicLogo = icon;
                 __instance.Title = LKey.ScoreData.Get(musicID);
-                __instance.Singer = LKey.Text.HUD_Score_Singer.WithParam("name", data.Artist);
-                __instance.Composer = LKey.Text.HUD_Score_Composer.WithParam("name", data.Composer);
-                __instance.Writer = LKey.Text.HUD_Score_Lyricist.WithParam("name", data.Lyricist);
-                __instance.Arrangement = LKey.Text.HUD_Score_Arrangement.WithParam("name", data.Arranger);
+                __instance.Singer = LKey.Text.HUD_Score_Singer.WithParam("name", LKey.ScoreData.Get(musicID + "_ARTIST"));
+                __instance.Composer = LKey.Text.HUD_Score_Composer.WithParam("name", LKey.ScoreData.Get(musicID + "_COMP"));
+                __instance.Writer = LKey.Text.HUD_Score_Lyricist.WithParam("name", LKey.ScoreData.Get(musicID + "_LYRICS"));
+                __instance.Arrangement = LKey.Text.HUD_Score_Arrangement.WithParam("name", LKey.ScoreData.Get(musicID + "_ARRAN"));
                 return false;
             }
             return true;

--- a/YunYunLoader/Patches/UIScoreDetail_Patches.cs
+++ b/YunYunLoader/Patches/UIScoreDetail_Patches.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using App;
+﻿using App;
 using App.Binding;
 using HarmonyLib;
 using UnityEngine;
@@ -13,12 +12,12 @@ namespace YunYunLoader.Patches
         {
             if (Plugin.ModdedSongs.TryGetValue(musicID, out ModdedScoreData? data))
             {
-                if (data == null)
+                if (data?.ID is null)
                     return true;
 
                 __instance.MusicId = musicID;
                 Sprite? icon = null;
-                __instance.HasMusicLogo = !string.IsNullOrWhiteSpace(data.Icon) && Plugin.LoadedSprites.TryGetValue(Path.GetFileNameWithoutExtension(data.Icon), out icon);
+                __instance.HasMusicLogo = !string.IsNullOrWhiteSpace(data.Icon) && Plugin.LoadedSprites.TryGetValue(data.ID, out icon);
                 __instance.MusicLogo = icon;
                 __instance.Title = LKey.ScoreData.Get(musicID);
                 __instance.Singer = LKey.Text.HUD_Score_Singer.WithParam("name", LKey.ScoreData.Get(musicID + "_ARTIST"));

--- a/YunYunLoader/Plugin.cs
+++ b/YunYunLoader/Plugin.cs
@@ -68,48 +68,55 @@ namespace YunYunLoader
                     continue;
                 }
 
-                if (data == null)
+                if (data is null)
                 {
                     Logger.LogError("Failed to parse song.json in " + dir);
-                    continue;
-                }
-
-                if (ModdedSongs.ContainsKey(data.ID!))
-                {
-                    Logger.LogWarning("Duplicate song ID " + data.ID + " in " + dir + ", skipping!");
                     continue;
                 }
 
                 bool failure = false;
                 foreach (FieldInfo f in typeof(ModdedScoreData).GetFields())
                 {
-                    if (f.GetValue(data) == null)
+                    if (f.GetValue(data) is null)
                     {
                         Logger.LogError("Missing field " + f.Name + " in song.json in " + dir);
                         failure = true;
                     }
                 }
-                if (failure)
+                if (failure || data.ID is null)
                     continue;
+                
+                if (ModdedSongs.ContainsKey(data.ID))
+                {
+                    Logger.LogWarning("Duplicate song ID " + data.ID + " in " + dir + ", skipping!");
+                    continue;
+                }
 
-                AudioClip? clip = await LoadOggAsync(dir + "\\" + data.Audio!);
-                if (clip == null)
+                AudioClip? clip = await LoadOggAsync(dir + "\\" + data.Audio);
+                if (clip is null)
                     continue;
 
                 if (!string.IsNullOrEmpty(data.Icon))
                 {
                     Texture2D? texture = await LoadTextureAsync(dir + "\\" + data.Icon);
-                    if (texture == null)
+                    if (texture is null)
                     {
                         Logger.LogWarning("Failed to load icon " + data.Icon + " from song.json in " + dir + ", skipping!");
                     }
                     else
                     {
                         Sprite sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0.5f));
-                        LoadedSprites[Path.GetFileNameWithoutExtension(data.Icon)] = sprite;
+                        if (!LoadedSprites.TryAdd(data.ID, sprite))
+                        {
+                            Logger.LogWarning(data.ID + " already has a loaded sprite, skipping!");
+                        }
                     }
                 }
-                LoadedAudioClips[Path.GetFileNameWithoutExtension(data.Audio!)] = clip;
+
+                if (!LoadedAudioClips.TryAdd(data.ID, clip))
+                {
+                    Logger.LogWarning(data.ID + " already has a loaded audio, skipping!");
+                }
                 foreach (ModdedLevelData l in data.Levels!)
                 {
                     ScoreData? score;
@@ -133,7 +140,7 @@ namespace YunYunLoader
                     l.ID = Path.GetFileNameWithoutExtension(l.Path);
                     l.Data = score;
                 }
-                ModdedSongs[data.ID!] = data;
+                ModdedSongs[data.ID] = data;
                 songsLoaded++;
             }
 

--- a/YunYunLoader/Plugin.cs
+++ b/YunYunLoader/Plugin.cs
@@ -4,27 +4,26 @@ using Cysharp.Threading.Tasks;
 using HarmonyLib;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using UnityEngine.Localization.Settings;
 using UnityEngine.Localization.Tables;
 using UnityEngine.Networking;
-using YunYunLoader;
 using YYNoteEditor;
 using Newtonsoft.Json;
 
-namespace YunyunLoader
+namespace YunYunLoader
 {
-    [BepInPlugin("YunYunLoader", "YunYunLoader", "1.1.0")]
+    [BepInPlugin("YunYunLoader", "YunYunLoader", "1.2.0")]
     public class Plugin : BaseUnityPlugin
     {
         private readonly Harmony Harmony = new Harmony("YunYunLoader");
 
         internal static ManualLogSource Log;
 
-        internal static Dictionary<string, AudioClip> LoadedAudioClips = new Dictionary<string, AudioClip>();
-        internal static Dictionary<string, ModdedScoreData> ModdedSongs = new Dictionary<string, ModdedScoreData>();
+        internal static readonly Dictionary<string, AudioClip> LoadedAudioClips = new Dictionary<string, AudioClip>();
+        internal static readonly Dictionary<string, Sprite> LoadedSprites = new Dictionary<string, Sprite>();
+        internal static readonly Dictionary<string, ModdedScoreData> ModdedSongs = new Dictionary<string, ModdedScoreData>();
 
         internal static bool IsModdedSongResult;
         internal static bool SavedIsPlayedPost;
@@ -49,7 +48,6 @@ namespace YunyunLoader
 
         async UniTaskVoid Start()
         {
-            StringTable table = LocalizationSettings.StringDatabase.GetTable("ScoreData");
             int songsLoaded = 0;
             foreach (string dir in Directory.GetDirectories(SongsPath))
             {
@@ -61,7 +59,8 @@ namespace YunyunLoader
                 ModdedScoreData? data;
                 try
                 {
-                     data = JsonConvert.DeserializeObject<ModdedScoreData>(File.ReadAllText(dir + "\\song.json"));
+                    string json = await File.ReadAllTextAsync(dir + "\\song.json");
+                    data = JsonConvert.DeserializeObject<ModdedScoreData>(json);
                 }
                 catch
                 {
@@ -97,13 +96,27 @@ namespace YunyunLoader
                 if (clip == null)
                     continue;
 
+                if (!string.IsNullOrEmpty(data.Icon))
+                {
+                    Texture2D? texture = await LoadTextureAsync(dir + "\\" + data.Icon);
+                    if (texture == null)
+                    {
+                        Logger.LogWarning("Failed to load icon " + data.Icon + " from song.json in " + dir + ", skipping!");
+                    }
+                    else
+                    {
+                        Sprite sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0.5f));
+                        LoadedSprites[Path.GetFileNameWithoutExtension(data.Icon)] = sprite;
+                    }
+                }
                 LoadedAudioClips[Path.GetFileNameWithoutExtension(data.Audio!)] = clip;
                 foreach (ModdedLevelData l in data.Levels!)
                 {
                     ScoreData? score;
                     try
                     {
-                        score = JsonConvert.DeserializeObject<ScoreData>(File.ReadAllText(dir + "\\" + l.Path));
+                        string json = await File.ReadAllTextAsync(dir + "\\" + l.Path);
+                        score = JsonConvert.DeserializeObject<ScoreData>(json);
                     }
                     catch
                     {
@@ -118,30 +131,41 @@ namespace YunyunLoader
                     }
 
                     l.ID = Path.GetFileNameWithoutExtension(l.Path);
-                    table.AddEntry(l.ID + "_EDITOR", l.Editor);
                     l.Data = score;
                 }
-                AddLocalizationData(data, ref table);
                 ModdedSongs[data.ID!] = data;
                 songsLoaded++;
             }
 
+            LocalizedStringDatabase db = LocalizationSettings.StringDatabase;
+            PopulateScoreDataTable(db.GetTable("ScoreData"));
+            // hook our table postprocessor into the localization system, the base game doesn't use it
+            db.TablePostprocessor = new ScoreDataTablePostprocessor(db.TablePostprocessor);
+
             Logger.LogInfo("Loaded " + songsLoaded + " custom songs!");
         }
 
-        internal static bool TryGetSongByTitle(string musicName, out ModdedScoreData result)
+        internal static void PopulateScoreDataTable(StringTable table)
         {
-            result = ModdedSongs.Values.FirstOrDefault(x => x.Title == musicName);
-            return result != null;
-        }
+            // modded songs only have one language (for now), so just use whatever it is every time regardless of locale
+            foreach (ModdedScoreData data in ModdedSongs.Values)
+            {
+                table.AddEntry(data.ID, data.Title);
+                table.AddEntry(data.ID + "_ARTIST", data.Artist);
+                table.AddEntry(data.ID + "_LISTARTIST", data.ListArtist);
+                table.AddEntry(data.ID + "_LYRICS", data.Lyricist);
+                table.AddEntry(data.ID + "_COMP", data.Composer);
+                table.AddEntry(data.ID + "_ARRAN", data.Arranger);
 
-        private void AddLocalizationData(ModdedScoreData data, ref StringTable table)
-        {
-            table.AddEntry(data.ID, data.Title);
-            table.AddEntry(data.ID + "_ARTIST", data.Artist);
-            table.AddEntry(data.ID + "_LYRICS", data.Lyricist);
-            table.AddEntry(data.ID + "_COMP", data.Composer);
-            table.AddEntry(data.ID + "_ARRAN", data.Arranger);
+                if (data.Levels == null)
+                    continue;
+
+                foreach (ModdedLevelData l in data.Levels)
+                {
+                    if (!string.IsNullOrEmpty(l.ID))
+                        table.AddEntry(l.ID + "_EDITOR", l.Editor);
+                }
+            }
         }
 
         private async UniTask<AudioClip?> LoadOggAsync(string path)
@@ -157,7 +181,25 @@ namespace YunyunLoader
                 Log.LogError("Failed to load .ogg file from " + path);
                 return null;
             }
+            
             return DownloadHandlerAudioClip.GetContent(www);
+        }
+        
+        private async UniTask<Texture2D?> LoadTextureAsync(string path)
+        {
+            string uri = Utility.ConvertToWWWFormat(path);
+            using UnityWebRequest www = UnityWebRequestTexture.GetTexture(uri);
+            var operation = www.SendWebRequest();
+            while (!operation.isDone)
+                await UniTask.Yield();
+
+            if (www.result != UnityWebRequest.Result.Success)
+            {
+                Log.LogError("Failed to load .png/.jpg file from " + path);
+                return null;
+            }
+            
+            return DownloadHandlerTexture.GetContent(www);
         }
     }
 }

--- a/YunYunLoader/ScoreDataTablePostprocessor.cs
+++ b/YunYunLoader/ScoreDataTablePostprocessor.cs
@@ -1,0 +1,25 @@
+using UnityEngine.Localization.Settings;
+using UnityEngine.Localization.Tables;
+
+namespace YunYunLoader
+{
+    // unity wipes localization tables whenever the language is changed
+    // luckily, the game doesn't utilize the postprocessor so we can utilize it ourselves to repopulate modded metadata
+    internal class ScoreDataTablePostprocessor : ITablePostprocessor
+    {
+        private readonly ITablePostprocessor? Previous;
+
+        public ScoreDataTablePostprocessor(ITablePostprocessor? previous)
+        {
+            Previous = previous;
+        }
+
+        public void PostprocessTable(LocalizationTable table)
+        {
+            Previous?.PostprocessTable(table);
+
+            if (table is StringTable stringTable && table.TableCollectionName == "ScoreData")
+                Plugin.PopulateScoreDataTable(stringTable);
+        }
+    }
+}

--- a/YunYunLoader/YunYunLoader.csproj
+++ b/YunYunLoader/YunYunLoader.csproj
@@ -67,11 +67,17 @@
     <Reference Include="UnityEngine.JSONSerializeModule">
       <HintPath>$(LibRoot)\Yunyun_Syndrome_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>$(LibRoot)\Yunyun_Syndrome_Data\Managed\UnityEngine.UI.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule">
       <HintPath>$(LibRoot)\Yunyun_Syndrome_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule">
       <HintPath>$(LibRoot)\Yunyun_Syndrome_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestTextureModule">
+      <HintPath>$(LibRoot)\Yunyun_Syndrome_Data\Managed\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
     </Reference>
     <Reference Include="UVMBinding">
       <HintPath>$(LibRoot)\Yunyun_Syndrome_Data\Managed\UVMBinding.dll</HintPath>


### PR DESCRIPTION
- Added a new required ListArtist field to `song.json`. This field is displayed underneath the song Title in the song list.
- Added a new optional Icon field to `song.json`. This icon is displayed next to the song metadata when clicked on.
   - While optional, its presence in the `song.json` is still required and can default to an empty string, e.g. `"Icon": ""`
- Fixed a broken patch that caused song metadata to not properly refresh.
- Fixed song metadata disappearing when switching languages.